### PR TITLE
Python api enhancements

### DIFF
--- a/python/osmx/osmx.py
+++ b/python/osmx/osmx.py
@@ -6,8 +6,8 @@ import capnp
 capnp.remove_import_hook()
 messages_capnp = capnp.load(os.path.join(os.path.dirname(__file__), 'messages.capnp'))
 
-def tag_dict(tag_list):
-    it = enumerate(tag_list)
+def tag_dict(message):
+    it = enumerate(message.tags)
     d = {}
     for x in it:
         d[x[1]] = next(it)[1]
@@ -29,62 +29,13 @@ class Transaction:
     def __exit__(self,*args,**kwargs):
         self._handle.__exit__(*args,**kwargs)
 
-class Index:
-    def __init__(self):
-        pass
-
-class Index:
-    def __init__(self,txn,name):
-        self.txn = txn
-        self._handle = txn.env._handle.open_db(name,txn=txn._handle,integerkey=True,create=False,dupsort=True,integerdup=True,dupfixed=True)
-
-    def __getitem__(self,obj_id):
-        cursor = self.txn._handle.cursor(self._handle)
-        cursor.set_key(int(obj_id).to_bytes(8,byteorder=sys.byteorder))
-        retval = [int.from_bytes(data,byteorder=sys.byteorder,signed=False) for data in cursor.iternext_dup()]
-        cursor.close()
-        return retval
-
-    # TODO deprecate get
-    def get(self,obj_id):
-        return self[obj_id]
-
-class Table:
-    def __init__(self,txn,name):
-        self.txn = txn
-        self._handle = txn.env._handle.open_db(name,txn=txn._handle,integerkey=True,create=False)
-
-    def _get_bytes(self,elem_id):
-        return self.txn._handle.get(int(elem_id).to_bytes(8,byteorder=sys.byteorder),db=self._handle)
-
-    def __contains__(self,key):
-        if self._get_bytes(key):
-            return True
-        return False
-
-    def __getitem__(self,oid):
-        msg = self._get_bytes(oid)
-        if not msg:
-            return None
-        return self.msgclass.from_bytes(msg)
-
-    # TODO deprecate get
-    def get(self,oid):
-        return self[oid]
-
-    def __iter__(self):
-        cursor = self.txn._handle.cursor(self._handle)
-        cursor.first()
-        for o in iter(cursor):
-            obj_id = int.from_bytes(o[0],byteorder=sys.byteorder,signed=False)
-            yield (obj_id,self.msgclass.from_bytes(o[1]))
-
-class Locations(Table):
+class Locations:
     def __init__(self,txn):
-        super().__init__(txn,b'locations')
+        self.txn = txn
+        self._handle = txn.env._handle.open_db(b'locations',txn=txn._handle,integerkey=True,create=False)
 
     def __getitem__(self,node_id):
-        msg = self._get_bytes(node_id)
+        msg = self.txn._handle.get(int(node_id).to_bytes(8,byteorder=sys.byteorder),db=self._handle)
         if not msg:
             return None
         return (
@@ -105,20 +56,60 @@ class Locations(Table):
                 int.from_bytes(msg[8:12],byteorder=sys.byteorder,signed=False)
             ))
 
-class Nodes(Table):
+class MessageTable:
+    def __init__(self,txn,name):
+        self.txn = txn
+        self._handle = txn.env._handle.open_db(name,txn=txn._handle,integerkey=True,create=False)
+
+    def _get_bytes(self,elem_id):
+        return self.txn._handle.get(int(elem_id).to_bytes(8,byteorder=sys.byteorder),db=self._handle)
+
+    # convenience method to check for the presence of a object ID
+    # without calling msgclass.from_bytes
+    def __contains__(self,key):
+        if self._get_bytes(key):
+            return True
+        return False
+
+    def __getitem__(self,oid):
+        msg = self._get_bytes(oid)
+        if not msg:
+            return None
+        return self.msgclass.from_bytes(msg)
+
+    def __iter__(self):
+        cursor = self.txn._handle.cursor(self._handle)
+        cursor.first()
+        for o in iter(cursor):
+            obj_id = int.from_bytes(o[0],byteorder=sys.byteorder,signed=False)
+            yield (obj_id,self.msgclass.from_bytes(o[1]))
+
+class Nodes(MessageTable):
     def __init__(self,txn):
         super().__init__(txn,b'nodes')
         self.msgclass = messages_capnp.Node
 
-class Ways(Table):
+class Ways(MessageTable):
     def __init__(self,txn):
         super().__init__(txn,b'ways')
         self.msgclass = messages_capnp.Way
 
-class Relations(Table):
+class Relations(MessageTable):
     def __init__(self,txn):
         super().__init__(txn,b'relations')
         self.msgclass = messages_capnp.Relation
+
+class Index:
+    def __init__(self,txn,name):
+        self.txn = txn
+        self._handle = txn.env._handle.open_db(name,txn=txn._handle,integerkey=True,create=False,dupsort=True,integerdup=True,dupfixed=True)
+
+    def __getitem__(self,obj_id):
+        cursor = self.txn._handle.cursor(self._handle)
+        cursor.set_key(int(obj_id).to_bytes(8,byteorder=sys.byteorder))
+        retval = [int.from_bytes(data,byteorder=sys.byteorder,signed=False) for data in cursor.iternext_dup()]
+        cursor.close()
+        return retval
 
 class NodeWay(Index):
     def __init__(self,txn):


### PR DESCRIPTION
@CloudNiner 

Some small Python API breaking changes (I should bump major version on PyPI)

`osmx.tags_dict(way.tags)` becomes `osmx.tags_dict(way)`

`ways.get(way_id)` becomes `ways[way_id]`

Two new API functions:

Check for the existence of a OSM ID in a table: `if way_id not in ways`

Iterate through all OSM entities in a table: `for relation_id, relation in relations`

Example code using new API methods:

```python
import sys
import osmx

env = osmx.Environment(sys.argv[1])
with osmx.Transaction(env) as txn:
    locations = osmx.Locations(txn)
    ways = osmx.Ways(txn)
    relations = osmx.Relations(txn)

    for relation_id, relation in relations:
        tags = osmx.tag_dict(relation)
        if 'type' in tags and tags['type'] == 'boundary':
            for member in relation.members:
                if member.type == 'way' and member.ref not in ways:
                    print(f"Relation {relation_id} missing way {member.ref}")
```
