### PR TITLE
Fix .poly file parsing and add support for multiple polygons

### DIFF
--- a/include/osmx/region.h
+++ b/include/osmx/region.h
@@ -14,5 +14,6 @@ public:
 
 private:
 	void AddS2RegionFromGeometry(nlohmann::json &geometry);
+	void AddS2RegionFromPolyFile(std::istringstream &file);
 	std::vector<std::unique_ptr<S2Region>> mRegions;
 };


### PR DESCRIPTION
First problem was that latitude and longitude were reverted, so now it parses `lon` 1st
I also added support for parsing multiple polygons