### PR TITLE
Fix macOS programming guide

### DIFF
--- a/docs/PROGRAMMING_GUIDE.md
+++ b/docs/PROGRAMMING_GUIDE.md
@@ -24,7 +24,7 @@ via Apt package manager: `sudo apt install cmake clang libbz2-dev libz-dev libex
     cmake -DCMAKE_BUILD_TYPE=Release .
     make
 
-*macOS note: If OpenSSL is installed through Homebrew, you may need to add an option to your cmake command: -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2s/include/*
+*macOS note: If OpenSSL is installed through Homebrew, you may need to add an option to your cmake command: `-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl\@3`
 
 ## Using the C++ Headers
 


### PR DESCRIPTION
The previous macOS build intructions don’t seem to work anymore.