### PR TITLE
docs: Update openssl path

### DIFF
--- a/docs/PROGRAMMING_GUIDE.md
+++ b/docs/PROGRAMMING_GUIDE.md
@@ -25,6 +25,7 @@ via Apt package manager: `sudo apt install cmake clang libbz2-dev libz-dev libex
     make
 
 *macOS note: If OpenSSL is installed through Homebrew, you may need to add an option to your cmake command: `-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl\@3`
+For macOS systems with Apple Silicon, this path is `-DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl\@3`
 
 ## Using the C++ Headers
 


### PR DESCRIPTION
This path has changed again with Apple Silicon and ARM libraries: https://docs.brew.sh/Installation