### PR TITLE
Expand documentation of file layout

### DIFF
--- a/docs/PROGRAMMING_GUIDE.md
+++ b/docs/PROGRAMMING_GUIDE.md
@@ -31,11 +31,11 @@ For macOS systems with Apple Silicon, this path is `-DOPENSSL_ROOT_DIR=/opt/home
 
 ### Example: Way ID to WKT
 
-See [examples/way_wkt.cpp](https://github.com/protomaps/OSMExpress/blob/master/examples/way_wkt.cpp) for a commented program.
+See [examples/way_wkt.cpp](https://github.com/protomaps/OSMExpress/blob/main/examples/way_wkt.cpp) for a commented program.
 
 ### Example: Bbox to Way WKTs
 
-See [examples/way_wkt.cpp](https://github.com/protomaps/OSMExpress/blob/master/examples/way_wkt.cpp) for a commented program.
+See [examples/bbox_wkt.cpp](https://github.com/protomaps/OSMExpress/blob/main/examples/way_wkt.cpp) for a commented program.
 
 ## Python
 


### PR DESCRIPTION
I added some details to the documentation about the contents and purpose of the various LMDB tables, and on how `Location` structs are encoded. And I fixed a couple of stale links.