### PR TITLE
Build with C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 set(CMAKE_C_COMPILER "/usr/bin/clang")
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 project(OSMExpress)
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -g")
 set(CMAKE_CXX_FLAGS "-Wno-deprecated")
 set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "-pthread")
+set(CMAKE_CXX_STANDARD 23)
 set(OSMX_VERSION "0.2.0")
 set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
 set(ROARING_BUILD_STATIC ON CACHE INTERNAL "")
@@ -134,11 +135,7 @@ target_link_libraries(
     osmx
     bz2 CapnProto::capnp cxxopts::cxxopts expat LMDB::LMDB roaring s2 z)
 
-set_property(TARGET osmx PROPERTY CXX_STANDARD 14)
-
 add_executable(osmxTest test/test_region.cpp src/region.cpp)
-
-set_property(TARGET osmxTest PROPERTY CXX_STANDARD 14)
 
 target_include_directories(
     osmxTest
@@ -164,8 +161,6 @@ add_library(
     src/extract.cpp
     src/update.cpp
     src/region.cpp)
-
-set_property(TARGET osmx-static PROPERTY CXX_STANDARD 14)
 
 target_include_directories(
     osmx-static


### PR DESCRIPTION
The current version of the S2 geometry library does not support building with C++14 anymore.